### PR TITLE
Added workload identity federation support & updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,14 @@ resource repository 'AzureDevOpsRepository' = {
 output id string = project.projectId
 ```
 
-## Security
+## Azure DevOps authentication
 
-Prefer environment variable over passing PAT as a property. Secrets in parameters can leak into logs. Never commit real PATs. Exploring ways to use Workload Identity Federation instead of PAT.
+This extension supports two authentication methods for Azure DevOps:
 
-Export your PAT to avoid putting secrets in files:
-
-```bash
-export AZDO_PAT="<your pat>"
-```
+|Type|Description|Other|
+|---|---|---|
+|Personal Access Token (PAT)|A PAT is a token that you can use to authenticate with Azure DevOps. It is less secure than Azure Entra access tokens and should be used with caution.|Consider using Azure Entra tokens instead.|
+|Workload Identity Federation|Azure Entra access tokens are more secure and should be preferred over PATs. They can be obtained using Azure Entra ID authentication.| When using this local-deploy feature in an Azure Pipeline, make sure the service principal used has the required permissions in Azure DevOps. |
 
 ## Disclaimer
 

--- a/Sample/bicepconfig.json
+++ b/Sample/bicepconfig.json
@@ -3,7 +3,7 @@
     "localDeploy": true
   },
   "extensions": {
-    "azuredevops": "br:azuredevopsbicep.azurecr.io/extensions/azuredevops:0.1.4" // ACR
+    "azuredevops": "br:azuredevopsbicep.azurecr.io/extensions/azuredevops:0.1.10" // ACR
     // "azuredevops": "../src/bin/azure-devops-extension" // local
   },
   "implicitExtensions": []

--- a/src/DevOpsExtension.csproj
+++ b/src/DevOpsExtension.csproj
@@ -13,6 +13,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Azure.Bicep.Local.Extension" Version="0.37.4" />
+        <PackageReference Include="Azure.Identity" Version="1.14.2" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
         <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.112" PrivateAssets="All" />
     </ItemGroup>

--- a/src/Handlers/AzureDevOpsResourceHandlerBase.cs
+++ b/src/Handlers/AzureDevOpsResourceHandlerBase.cs
@@ -38,6 +38,7 @@ public abstract class AzureDevOpsResourceHandlerBase<TProps, TIdentifiers>
         var pat = configuration.AccessToken ?? Environment.GetEnvironmentVariable("AZDO_PAT");
         if (!string.IsNullOrWhiteSpace(pat))
         {
+            Console.WriteLine("Warning: A personal access token (PAT) is less secure than Azure Entra access tokens. Consider using Azure Entra tokens instead.");
             var authToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{pat}"));
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authToken);
             return client;
@@ -52,7 +53,7 @@ public abstract class AzureDevOpsResourceHandlerBase<TProps, TIdentifiers>
             var token = credential.GetToken(new TokenRequestContext(new[] { "499b84ac-1321-427f-aa17-267ca6975798/.default" })); // GUID is the well-known resource id of the Azure DevOsp rest api
             if (string.IsNullOrWhiteSpace(token.Token))
             {
-                throw new InvalidOperationException("Empty Azure AD access token returned for Azure DevOps scope.");
+                throw new InvalidOperationException("Empty Azure Entra access token returned for Azure DevOps scope.");
             }
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
             return client;

--- a/src/Handlers/AzureDevOpsResourceHandlerBase.cs
+++ b/src/Handlers/AzureDevOpsResourceHandlerBase.cs
@@ -4,6 +4,8 @@ using System.Text;
 using System.Text.Json;
 using Bicep.Local.Extension.Host.Handlers;
 using DevOpsExtension.Models;
+using Azure.Identity;
+using Azure.Core;
 
 namespace DevOpsExtension.Handlers;
 
@@ -30,16 +32,42 @@ public abstract class AzureDevOpsResourceHandlerBase<TProps, TIdentifiers>
 
     protected static HttpClient CreateClient(Configuration configuration)
     {
-        var pat = configuration.AccessToken ?? Environment.GetEnvironmentVariable("AZDO_PAT");
-        if (string.IsNullOrWhiteSpace(pat))
-        {
-            throw new InvalidOperationException("A PAT must be supplied via property 'pat' or AZDO_PAT environment variable.");
-        }
         var client = new HttpClient();
-        var authToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{pat}"));
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authToken);
         client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        return client;
+
+        var pat = configuration.AccessToken ?? Environment.GetEnvironmentVariable("AZDO_PAT");
+        if (!string.IsNullOrWhiteSpace(pat))
+        {
+            var authToken = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{pat}"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authToken);
+            return client;
+        }
+
+        //    Resource ID for Azure DevOps first-party app: 499b84ac-1321-427f-aa17-267ca6975798
+        //    Use ".default" scope syntax for AAD v2 endpoint.
+        try
+        {
+            // Static cache to avoid re-instantiating credentials repeatedly.
+            var credential = DefaultAzureDevOpsCredential.Instance;
+            var token = credential.GetToken(new TokenRequestContext(new[] { "499b84ac-1321-427f-aa17-267ca6975798/.default" })); // GUID is the well-known resource id of the Azure DevOsp rest api
+            if (string.IsNullOrWhiteSpace(token.Token))
+            {
+                throw new InvalidOperationException("Empty Azure AD access token returned for Azure DevOps scope.");
+            }
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+            return client;
+        }
+        catch (Exception ex)
+        {
+            client.Dispose();
+            throw new InvalidOperationException("Failed to acquire Azure DevOps credentials. Provide a PAT (property 'pat' or AZDO_PAT) or ensure a federated / managed identity is configured.", ex);
+        }
+    }
+
+    // Internal helper to cache DefaultAzureCredential instance (which can be costly to build repeatedly)
+    private static class DefaultAzureDevOpsCredential
+    {
+        internal static readonly DefaultAzureCredential Instance = new(new DefaultAzureCredentialOptions());
     }
 
     protected static string? TryGetOperationIdFromResponse(HttpResponseMessage response, JsonElement? parsedBody)


### PR DESCRIPTION
This pull request adds support for Workload Identity Federation (WIF) flows. Omit the personal access token, and WIF authentication will take over.

Deployment without PAT using Azure PowerShell and a WIF-configured service connection with permissions in Azure DevOps:

![WIF](https://github.com/user-attachments/assets/23ebfa64-8632-4a5e-8e9f-d0bd38975f3a)
